### PR TITLE
fix/api: noms de contraintes rendus uniques

### DIFF
--- a/api/app/models/db.py
+++ b/api/app/models/db.py
@@ -43,8 +43,11 @@ class Base(DeclarativeBase):
 marche_titulaire_table = Table(
     "marche_titulaire_table",
     Base.metadata,
-    Column("uid_marche", ForeignKey("marche.uid", name="marche_fk")),
-    Column("uid_titulaire", ForeignKey("structure.uid", name="titulaire_fk")),
+    Column("uid_marche", ForeignKey("marche.uid", name="marche_titulaire_marche_fk")),
+    Column(
+        "uid_titulaire",
+        ForeignKey("structure.uid", name="marche_titulaire_titulaire_fk"),
+    ),
 )
 
 
@@ -82,7 +85,7 @@ class StructureInfogreffe(Base):
 class ModificationSousTraitance(Base):
     uid: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     uid_acte_sous_traitance: Mapped[int] = mapped_column(
-        ForeignKey("acte_sous_traitance.uid", name="acte_fk")
+        ForeignKey("acte_sous_traitance.uid", name="modif_sous_traitance_acte_fk")
     )
     duree_mois: Mapped[int | None]
     date_notif: Mapped[date]
@@ -92,11 +95,13 @@ class ModificationSousTraitance(Base):
 
 class ActeSousTraitance(Base):
     uid: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
-    uid_marche: Mapped[int] = mapped_column(ForeignKey("marche.uid", name="marche_fk"))
+    uid_marche: Mapped[int] = mapped_column(
+        ForeignKey("marche.uid", name="acte_sous_traitance_marche_fk")
+    )
     id: Mapped[int]  # unique par marché, dans l'ordre de création
     sous_traitant: Mapped[Structure] = relationship()  # 1*
     uid_sous_traitant: Mapped[int] = mapped_column(
-        ForeignKey("structure.uid", name="sous_traitant_fk")
+        ForeignKey("structure.uid", name="acte_sous_traitance_sous_traitant_fk")
     )
     duree_mois: Mapped[int | None]
     duree_mois_initiale: Mapped[int | None]
@@ -121,15 +126,22 @@ modification_titulaire_table = Table(
     Base.metadata,
     Column(
         "uid_modification",
-        ForeignKey("modification_marche.uid", name="modification_fk"),
+        ForeignKey(
+            "modification_marche.uid", name="modification_titulaire_modification_fk"
+        ),
     ),
-    Column("uid_titulaire", ForeignKey("structure.uid", name="titulaire_fk")),
+    Column(
+        "uid_titulaire",
+        ForeignKey("structure.uid", name="modification_titulaire_titulaire_fk"),
+    ),
 )
 
 
 class ModificationMarche(Base):
     uid: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
-    uid_marche: Mapped[int] = mapped_column(ForeignKey("marche.uid", name="marche_fk"))
+    uid_marche: Mapped[int] = mapped_column(
+        ForeignKey("marche.uid", name="modif_marche_marche_fk")
+    )
     id: Mapped[int]  # id unique croissant par marché
     duree_mois: Mapped[int | None]
     date_notification: Mapped[date]
@@ -155,7 +167,7 @@ class Lieu(Base):
 class Tarif(Base):
     uid: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     uid_donnee_execution: Mapped[int] = mapped_column(
-        ForeignKey("donnee_execution.uid", name="donnee_execution_fk")
+        ForeignKey("donnee_execution.uid", name="tarif_donnee_execution_fk")
     )
     intitule: Mapped[str] = mapped_column(String(255))
     tarif: Mapped[Decimal] = mapped_column(DECIMAL(12, 2))
@@ -164,7 +176,7 @@ class Tarif(Base):
 class DonneeExecution(Base):
     uid: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     uid_contrat_concession: Mapped[int] = mapped_column(
-        ForeignKey("contrat_concession.uid", name="concession_fk")
+        ForeignKey("contrat_concession.uid", name="donnee_execution_concession_fk")
     )
     date_publication: Mapped[date]
     depenses_investissement: Mapped[Decimal] = mapped_column(DECIMAL(12, 2))
@@ -173,19 +185,25 @@ class DonneeExecution(Base):
 
 class ConsiderationEnvMarche(Base):
     uid: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
-    uid_marche: Mapped[int] = mapped_column(ForeignKey("marche.uid", name="marche_fk"))
+    uid_marche: Mapped[int] = mapped_column(
+        ForeignKey("marche.uid", name="cons_env_marche_fk")
+    )
     consideration: Mapped[int]
 
 
 class ConsiderationSocialeMarche(Base):
     uid: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
-    uid_marche: Mapped[int] = mapped_column(ForeignKey("marche.uid", name="marche_fk"))
+    uid_marche: Mapped[int] = mapped_column(
+        ForeignKey("marche.uid", name="cons_soc_marche_fk")
+    )
     consideration: Mapped[int]
 
 
 class TechniqueAchatMarche(Base):
     uid: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
-    uid_marche: Mapped[int] = mapped_column(ForeignKey("marche.uid", name="marche_fk"))
+    uid_marche: Mapped[int] = mapped_column(
+        ForeignKey("marche.uid", name="tech_achat_marche_fk")
+    )
     technique: Mapped[int]
 
 
@@ -194,11 +212,11 @@ class Marche(Base):
     id: Mapped[str] = mapped_column(String(16))
     acheteur: Mapped[Structure] = relationship()  # 1*
     uid_acheteur: Mapped[int] = mapped_column(
-        ForeignKey("structure.uid", name="acheteur_fk")
+        ForeignKey("structure.uid", name="marche_acheteur_fk")
     )
     nature: Mapped[int]  # enum NatureMarche
     objet: Mapped[str] = mapped_column(Text())  # max 1k
-    code_cpv: Mapped[int] = mapped_column(ForeignKey("cpv.code", name="cpv_fk"))
+    code_cpv: Mapped[int] = mapped_column(ForeignKey("cpv.code", name="marche_cpv_fk"))
     cpv: Mapped[CPV] = relationship()
     categorie: Mapped[int]  # enum CategorieMarche
     techniques_achat: Mapped[list[TechniqueAchatMarche]] = relationship()
@@ -207,7 +225,7 @@ class Marche(Base):
     )
     accord_cadre: Mapped["Marche | None"] = relationship()  # 1*
     uid_accord_cadre: Mapped[None | int] = mapped_column(
-        ForeignKey("marche.uid", name="accord_cadre_fk")
+        ForeignKey("marche.uid", name="marche_accord_cadre_fk")
     )
     marche_innovant: Mapped[bool]
     ccag: Mapped[int | None]
@@ -219,7 +237,9 @@ class Marche(Base):
     actes_sous_traitance: Mapped[list[ActeSousTraitance]] = relationship()
     procedure: Mapped[int | None]  # enum ProcedureMarche
     lieu: Mapped[Lieu] = relationship()  # 1*
-    uid_lieu: Mapped[int | None] = mapped_column(ForeignKey("lieu.uid", name="lieu_fk"))
+    uid_lieu: Mapped[int | None] = mapped_column(
+        ForeignKey("lieu.uid", name="marche_lieu_fk")
+    )
     duree_mois: Mapped[int]
     duree_mois_initiale: Mapped[int]
     date_notification: Mapped[date]
@@ -302,7 +322,7 @@ class Marche(Base):
 class ModificationConcession(Base):
     uid: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     uid_concession: Mapped[int] = mapped_column(
-        ForeignKey("contrat_concession.uid", name="concession_fk")
+        ForeignKey("contrat_concession.uid", name="modif_concession_concession_fk")
     )
     id: Mapped[int]  # id unique croissant par concession
     date_signature: Mapped[date]
@@ -315,10 +335,12 @@ concession_structure_table = Table(
     "concession_structure_table",
     Base.metadata,
     Column(
-        "uid_concession", ForeignKey("contrat_concession.uid", name="concession_fk")
+        "uid_concession",
+        ForeignKey("contrat_concession.uid", name="concession_structure_concession_fk"),
     ),
     Column(
-        "uid_concessionnaire", ForeignKey("structure.uid", name="concessionnaire_fk")
+        "uid_concessionnaire",
+        ForeignKey("structure.uid", name="concession_structure_concessionnaire_fk"),
     ),
 )
 
@@ -328,7 +350,7 @@ class ContratConcession(Base):
     id: Mapped[str] = mapped_column(String(16))
     autorite_concedante: Mapped[Structure] = relationship()  # 1*
     uid_autorite: Mapped[int] = mapped_column(
-        ForeignKey("structure.uid", name="autorite_fk")
+        ForeignKey("structure.uid", name="concession_autorite_fk")
     )
     nature: Mapped[int | None]  # enum NatureConcession
     objet: Mapped[str] = mapped_column(String(1_000))
@@ -386,7 +408,7 @@ class Erreur(Base):
     uid: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     decp: Mapped["DecpMalForme"] = relationship()
     uid_decp: Mapped[int] = mapped_column(
-        ForeignKey("decp_mal_forme.uid", name="decp_fk")
+        ForeignKey("decp_mal_forme.uid", name="erreur_decp_fk")
     )
     type: Mapped[str] = mapped_column(String(100))
     localisation: Mapped[str] = mapped_column(String(255))
@@ -398,7 +420,7 @@ class DecpMalForme(Base):
     decp: Mapped[str] = mapped_column(Text())
     erreurs: Mapped[list[Erreur]] = relationship(back_populates="decp")
     uid_structure: Mapped[int | None] = mapped_column(
-        ForeignKey(Structure.uid, name=("structure_fk")), default=None
+        ForeignKey(Structure.uid, name="decp_structure_fk"), default=None
     )
     structure: Mapped[Structure | None] = relationship()
     date_creation: Mapped[date | None]


### PR DESCRIPTION
Potentielle erreur d'unicité des noms de contraintes lors du déploiement sur certains MariaDB