### PR TITLE
Feat/api/filtre import siret

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ docker compose exec api sh -c "python app/importation.py decps --import-de-0"
 docker compose exec api sh -c "python app/importation.py structures"
 ```
 
+*Notes :*
+- L'import initial doit faire appel à l'option `--import-de-0` afin de (re)créer la base de données
+- Il est possible de n'importer qu'une fraction des marchés en filtrant par le SIRET des acheteurs en ajoutant la variable d'environnement SIRET contenant une liste de sirets séparés par des espaces. 
+
 Une fois l'import initial réalisé, un réimport partiel (marchés uniquement) peut être réalisé régulièrement avec la commande suivante.
 ````bash
 docker compose exec api sh -c "python app/importation.py decps

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -18,6 +18,7 @@ class Config(BaseSettings):
     API_ENTREPRISE_TOKEN: str
 
     SOURCES: str
+    SIRETS: str | None = None
 
 
 @lru_cache

--- a/api/app/importation.py
+++ b/api/app/importation.py
@@ -324,11 +324,17 @@ class ImportateurDecp:
                 x[
                     "modificationActeSousTraitance"
                 ].dateNotificationModificationSousTraitance
+                if "modificationActeSousTraitance" in x
+                else x[
+                    "modificationActesSousTraitance"
+                ].dateNotificationModificationSousTraitance
             ),
         ):
-            dmodif: ModificationActeSousTraitanceSchema = tmp_dma[
-                "modificationActeSousTraitance"
-            ]
+            dmodif: ModificationActeSousTraitanceSchema = (
+                tmp_dma["modificationActeSousTraitance"]
+                if "modificationActeSousTraitance" in tmp_dma
+                else tmp_dma["modificationActesSousTraitance"]
+            )
             if dmodif.id not in index_actes_sous_traitance:
                 raise CustomValidationError(
                     errors=[

--- a/api/app/importation.py
+++ b/api/app/importation.py
@@ -212,7 +212,7 @@ class ImportateurDecp:
             ),
             nature=data.nature.db_value,
             objet=data.objet,
-            code_cpv=data.codeCPV,
+            code_cpv=int(data.codeCPV.split("-")[0]),
             categorie=categorisation.CPV2categorie(data.codeCPV).db_value,
             modalites_execution=[
                 mod.db_value

--- a/api/app/importation.py
+++ b/api/app/importation.py
@@ -93,7 +93,12 @@ class CustomValidationError(Exception):
 
 
 class ImportateurDecp:
-    def __init__(self, session: Session, preload_db: bool = True):
+    def __init__(
+        self,
+        session: Session,
+        preload_db: bool = True,
+        sirets: list[str] | None = None,
+    ):
         self._cache_lieux: dict[str, Lieu] = {}
         self._cache_structures: dict[str, Structure] = {}
         self._cache_accords_cadre: dict[str, Marche] = {}
@@ -104,6 +109,8 @@ class ImportateurDecp:
         self._invalid_objects: int = 0
         self._started_at: float
         self._finished_at: float
+
+        self._sirets = sirets
 
         if preload_db:
             self.load_structures()
@@ -188,12 +195,15 @@ class ImportateurDecp:
     def marche_transformer(
         self,
         objet: dict[str, Any],
-    ) -> None:
+    ) -> bool:
         data: MarcheSchema | MarcheAncienSchema
         if objet.get("dateNotification") and int(objet["dateNotification"][:4]) >= 2024:
             data = MarcheSchema.model_validate(objet)
         else:
             data = MarcheAncienSchema.model_validate(objet)
+
+        if self._sirets and data.acheteur.id not in self._sirets:
+            return False
 
         marche = Marche(
             id=data.id,
@@ -379,12 +389,16 @@ class ImportateurDecp:
                 marche.titulaires = modif_marche.titulaires
 
         self._session.add(marche)
+        return True
 
     def concession_transformer(
         self,
         objet: dict[str, Any],
-    ) -> None:
+    ) -> bool:
         data = ConcessionSchema.model_validate(objet)
+
+        if self._sirets and data.autoriteConcedante.id not in self._sirets:
+            return False
 
         concession = ContratConcession(
             id=data.id,
@@ -456,6 +470,7 @@ class ImportateurDecp:
                 concession.duree_mois = modif_concession.duree_mois
 
         self._session.add(concession)
+        return True
 
     def build_entite_erreur(
         self,
@@ -527,8 +542,9 @@ class ImportateurDecp:
             liste = ijson.items(f, f"{item_path}.item")  # flux objet par objet
             for objet in liste:
                 try:
-                    transformer(objet)
-                    self._valid_objects += 1
+                    self._valid_objects += transformer(
+                        objet
+                    )  # retourne un booléen, le compteur n'est incrémenté qu'avec les True
                 except (ValidationError, CustomValidationError) as e:
                     self._session.add(self.build_entite_erreur(e, objet, type_contrat))
                     self._invalid_objects += 1
@@ -615,13 +631,15 @@ def decps(import_de_0: bool = False) -> None:  # pragma: no cover
             connexion.execute(text("SET FOREIGN_KEY_CHECKS = 1; "))
             connexion.commit()
 
-    sources: list[str] = get_config().SOURCES.split(" ")
+    config = get_config()
+    sirets: None | list[str] = config.SIRETS.split(" ") if config.SIRETS else None
+    sources: list[str] = config.SOURCES.split(" ")
     RAW_FILE = "./raw_data.json"
     CLEANED_FILE = "./data.json"
     log.info(f"📂 {len(sources)} sources détectées")
 
     with Session(get_engine()) as session:
-        importateur = ImportateurDecp(session=session)
+        importateur = ImportateurDecp(session=session, sirets=sirets)
 
         for source in track(sources):
             log.info(f"🌐 Téléchargement de {source}")

--- a/api/app/models/db.py
+++ b/api/app/models/db.py
@@ -3,7 +3,7 @@ from datetime import date
 from decimal import Decimal
 
 from sqlalchemy import Column, ForeignKey, String, Table, Text, UniqueConstraint
-from sqlalchemy.dialects.mysql import DECIMAL
+from sqlalchemy.dialects.mysql import DECIMAL, MEDIUMTEXT
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.ext.mutable import MutableList
 from sqlalchemy.orm import (
@@ -417,7 +417,7 @@ class Erreur(Base):
 
 class DecpMalForme(Base):
     uid: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
-    decp: Mapped[str] = mapped_column(Text())
+    decp: Mapped[str] = mapped_column(MEDIUMTEXT())
     erreurs: Mapped[list[Erreur]] = relationship(back_populates="decp")
     uid_structure: Mapped[int | None] = mapped_column(
         ForeignKey(Structure.uid, name="decp_structure_fk"), default=None


### PR DESCRIPTION
Suite à la discussion #47, le script d'import est modifié pour permettre d'importer seulement une partie du jeu de données en filtrant sur les SIRETs des acheteurs. Quelques aménagements sont aussi requis pour importer sans encombre le jeu national.